### PR TITLE
changed entrypoint script because of line ending bug

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -11,12 +11,8 @@ COPY . .
 # Install dependencies
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Copy the entrypoint script and make it executable
-COPY entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
-
 # Expose port 8000 for Django
 EXPOSE 8000
 
-# Use the entrypoint script to run migrations then start the server
-ENTRYPOINT ["/entrypoint.sh"]
+# Run migrations and start Django server
+ENTRYPOINT ["sh", "-c", "python manage.py migrate --noinput && exec python manage.py runserver 0.0.0.0:8000"]

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-# Run database migrations
-python manage.py migrate --noinput
-
-# Start the Django development server
-exec python manage.py runserver 0.0.0.0:8000


### PR DESCRIPTION
## Description
There was a bug where we changed the line seperator of the entrypoint.sh file which caused it to error when run. To make sure this doesn't happen in the future I have moved all logic back to the DockerFile

## Related Issue
BugFix

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
