### PR TITLE
nginx fix

### DIFF
--- a/terraform/modules/nginx_ec2/main.tf
+++ b/terraform/modules/nginx_ec2/main.tf
@@ -101,6 +101,7 @@ resource "aws_instance" "nginx" {
     server {
       listen 443 ssl;
       server_name ${var.domain_name};
+      client_max_body_size 50M;
 
       # SSL certificate from certbot
       ssl_certificate /etc/letsencrypt/live/${var.domain_name}/fullchain.pem;


### PR DESCRIPTION
## Description
There was a bug where uploaded images that were too big would get a 413 error. I increased the max allow request size to fix

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes