### PR TITLE
Scrum 79 order page auto update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "sep2025-project-team_001",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/web_app/src/pages/OrdersPage.js
+++ b/web_app/src/pages/OrdersPage.js
@@ -32,19 +32,35 @@ const OrdersPage = () => {
   };
 
   useEffect(() => {
-    axios
-      .get(`${process.env.REACT_APP_API_URL}/retrieve/orders/`)
-      .then((response) => {
-        setOrders(response.data);
-        setLoading(false);
-      })
-      .catch((error) => {
+    const fetchOrders = async () => {
+      try {
+        const response = await axios.get(
+          `${process.env.REACT_APP_API_URL}/retrieve/orders/`
+        );
+        const newOrders = response.data;
+
+        if (JSON.stringify(newOrders) !== JSON.stringify(orders)) { //checks if orders have changed, if same do nothing
+          setOrders(newOrders);
+        }
+
+        if (loading) {
+          setLoading(false); // Only clear loading on first fetch
+        }
+      } catch (error) {
         console.error('Error fetching orders:', error);
-        setLoading(false);
-      });
+        if (loading) {
+          setLoading(false);
+        }
+      }
+    };
+
+    fetchOrders(); // On Page entry
+
+    const intervalId = setInterval(fetchOrders, 3000); // Poll every 3s
+    return () => clearInterval(intervalId);
   }, []);
 
-  if (loading) {
+  if (loading && orders.length === 0) {
     return (
       <Container className="mt-5 text-center">
         <Spinner animation="border" role="status">


### PR DESCRIPTION
## Description
<!-- Provide a short description of the changes made in this PR -->
Updated load/spinner symbol to only display on page entry
Poll database every 3 seconds and update orders displayed
Only update orders page when database query returns new orders

## Related Issue
<!-- Link the issue this PR is solving (e.g., Fixes #123) -->
SCRUM-78-Orders-Page-Auto-Update

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
<!-- Add screenshots to show the UI changes or bug fixes -->

## Additional Notes
<!-- Any other information that reviewers should know -->
This method uses polling. Initially set at 3 seconds so it querys database every 3 seconds(this can be modified) this will charge a lot of money from AWS, so keep note.
